### PR TITLE
Feature/clinwikimap

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -60,6 +60,8 @@ const Map = (props) => {
     const [filtersData, setFiltersData] = useState({});
     const [categories, setCategories] = useState([]);
 
+    const clinWikiMap = getTeam() === "clinwiki";
+
     // set filterIds from firestore in useeffect
     useEffect(() => {
         document.title = getTeam().toUpperCase();
@@ -154,7 +156,7 @@ const Map = (props) => {
                 return arr;
             });
 
-        if (getTeam() == "clinwiki") {
+        if (clinWikiMap) {
             const parsed = queryString.parse(window.location.search);
             let clinWikiSearchHash = "";
 
@@ -164,29 +166,7 @@ const Map = (props) => {
             const clinwikiProviders = await loadClinwikiProviders(
                 clinWikiSearchHash
             );
-            clinwikiProviders.forEach((provider) => {
-                provs = [...provs, provider];
-                //@ts-ignore
-                let dataList = [];
-                //@ts-ignore
-                data.Disease.options.map((disease) => {
-                    dataList.push(disease.value.toLowerCase());
-                });
-                //@ts-ignore
-                if (provider.Disease) {
-                    //@ts-ignore
-                    provider.Disease.map((disease) => {
-                        if (!dataList.includes(disease.toLowerCase())) {
-                            dataList.push(disease);
-                            //@ts-ignore
-                            data.Disease.options.push({
-                                value: disease,
-                                label: disease,
-                            });
-                        }
-                    });
-                }
-            });
+            provs = [...provs, ...clinwikiProviders];
         }
 
         setProviders(provs);
@@ -606,7 +586,7 @@ const Map = (props) => {
                             )
                         )}
                     </div>
-                    {isSticky && renderTagControl()}
+                    {isSticky && !clinWikiMap && renderTagControl()}
                 </div>
                 <div className={classNames({ "row-nowrap": condition })}>
                     <div
@@ -628,7 +608,7 @@ const Map = (props) => {
                             />
                         )}
                         <div className="map-container">
-                            {!isSticky && renderTagControl()}
+                            {!isSticky && !clinWikiMap && renderTagControl()}
                             <div
                                 ref={cellScrollRef}
                                 className={classNames("cell-container", {
@@ -655,9 +635,7 @@ const Map = (props) => {
                                         {isEmpty(activeProviders)
                                             ? "No"
                                             : activeProviders.length}{" "}
-                                        {getTeam() === "clinwiki"
-                                            ? "trials"
-                                            : "providers"}{" "}
+                                        {clinWikiMap ? "trials" : "providers"}{" "}
                                         found
                                     </span>
                                 </div>

--- a/src/functions/loadClinwikiProviders.ts
+++ b/src/functions/loadClinwikiProviders.ts
@@ -1,0 +1,94 @@
+import { GOOGLE_API_KEY } from "../config/keys";
+
+async function providerFromId(nctId: string) {
+    const query = await fetch("https://app.clinwiki.org/graphql", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+        body: JSON.stringify({
+            query: `query {
+                    study (nctId: ${nctId}) {
+                      briefTitle
+                      briefSummary
+                      #latitude/longitude
+                      conditions
+                      facilities {
+                        state
+                        name
+                        contacts {
+                          phone
+                        }
+                        location {
+                          latitude
+                          longitude
+                        }
+                      }
+                    }
+                  }`,
+        }),
+    }).then((r) => r.json());
+    const provider = {
+        Disease: query?.data?.study?.conditions?.split("|") ?? [""],
+        address: [query?.data?.study?.facilities[0]?.name] ?? "Test",
+        description: query?.data?.study?.briefSummary ?? "",
+        facilityName: query?.data?.study?.briefTitle ?? "",
+        latitude: query?.data?.study?.facilities[0]?.location?.latitude ?? 0,
+        longitude: query?.data?.study?.facilities[0]?.location?.longitude ?? 0,
+        phoneNum: [query?.data?.study?.facilities[0]?.contacts[0]?.phone ?? ""],
+        team: "clinwiki",
+        website: `https://app.clinwiki.org/study/${nctId}`,
+    };
+    //TODO: default lat/long
+    if (
+        (provider.latitude === 0 || provider.longitude === 0) &&
+        !!provider.facilityName
+    ) {
+        const filteredName = (
+            provider.address + query?.data?.study?.facilities[0]?.state
+        ).replace(/[^a-zA-Z ]/g, "");
+        const newCoords = await fetch(
+            `https://maps.googleapis.com/maps/api/geocode/json?address=${filteredName}&key=${GOOGLE_API_KEY}`
+        ).then((r) => r.json());
+        console.log("nc", newCoords);
+        if (newCoords.status != "ZERO_RESULTS") {
+            provider.latitude =
+                newCoords["results"][0]["geometry"]["location"]["lat"];
+            provider.longitude =
+                newCoords["results"][0]["geometry"]["location"]["lng"];
+        }
+    }
+    //@ts-ignore
+    return provider;
+}
+
+async function loadClinwikiProviders(searchHash: string) {
+    const clinwikiProviders = [];
+    const clinwikiIds = await fetch("https://app.clinwiki.org/graphql", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+        body: JSON.stringify({
+            query: `query { search(searchHash: "${searchHash}")
+                {
+                studies {
+                nctId
+                    }
+                }}`,
+        }),
+    }).then((r) => r.json());
+    await Promise.all(
+        clinwikiIds.data.search.studies.map(async (id) => {
+            const provider = await providerFromId(id.nctId);
+            clinwikiProviders.push(provider);
+        })
+    );
+    return clinwikiProviders.filter(
+        (provider) => provider.latitude !== 0 && provider.longitude !== 0
+    );
+}
+
+export { loadClinwikiProviders };


### PR DESCRIPTION
# summary

Added the ability to pull in search results from ClinWiki's GraphQL API and render them using mapscout frontend.

Example url to test: http://localhost:3000/clinwiki?searchHash=Gg.NS.kk