### PR TITLE
Adds image backup and removes unnecessary google api calls

### DIFF
--- a/src/components/dashboard/AddProvider.tsx
+++ b/src/components/dashboard/AddProvider.tsx
@@ -19,6 +19,7 @@ import { providerRoute } from '../../routes/pathnames';
 import useWindowSize from '../../functions/useWindowSize';
 import promiseWithTimeout from '../../functions/promiseWithTimeout';
 import { GOOGLE_API_KEY } from '../../config/keys';
+import { storage } from '../../store';
 
 const uuidv4 = require('uuid/v4');
 
@@ -118,6 +119,16 @@ function AddProvider(props) {
           i.latitude = responseJson.results[0].geometry.location.lat;
           i.longitude = responseJson.results[0].geometry.location.lng;
         }
+        if (!i.imageURL) {
+          const res = await fetch(`https://maps.googleapis.com/maps/api/streetview?size=500x500&location=${i.latitude},${i.longitude}&fov=80&heading=70&pitch=0&key=${GOOGLE_API_KEY}`);
+          const blob = await res.blob();
+          const filename = i.facilityName + '.jpeg';
+          await storage.ref('images').child(filename).put(blob);
+          await storage.ref('images').child(filename).getDownloadURL()
+            .then((url) => {
+              i.imageURL = url;
+          });
+        }
       }
       await promiseWithTimeout(5000, props.firestore.set({ collection: 'providers', doc: i.facilityName }, i));
       props.history.push(providerRoute);
@@ -146,6 +157,16 @@ function AddProvider(props) {
         if (responseJson.results.length > 0 && responseJson.results[0].geometry.location) {
           i.latitude = responseJson.results[0].geometry.location.lat;
           i.longitude = responseJson.results[0].geometry.location.lng;
+        }
+        if (!i.imageURL) {
+          const res = await fetch(`https://maps.googleapis.com/maps/api/streetview?size=500x500&location=${i.latitude},${i.longitude}&fov=80&heading=70&pitch=0&key=${GOOGLE_API_KEY}`);
+          const blob = await res.blob();
+          const filename = i.facilityName + '.jpeg';
+          await storage.ref('images').child(filename).put(blob);
+          await storage.ref('images').child(filename).getDownloadURL()
+            .then((url) => {
+              i.imageURL = url;
+          });
         }
       }
       const { firestore } = props;

--- a/src/components/map/ProviderCell.tsx
+++ b/src/components/map/ProviderCell.tsx
@@ -26,12 +26,7 @@ export default ({
   useEffect(() => {
     async function fetchData() {
       try {
-        if (typeof item.imageURL === 'string') {
-          await setImage(item.imageURL);
-        } else {
-          const res = await fetch(`https://maps.googleapis.com/maps/api/streetview?size=100x100&location=${item.latitude},${item.longitude}&fov=80&heading=70&pitch=0&key=${GOOGLE_API_KEY}`);
-          setImage(res.url);
-        }
+        await setImage(item.imageURL);
         setIsLoading(false);
       } catch (e) {
         console.log(e);

--- a/src/components/subcomponents/ProviderInfo.tsx
+++ b/src/components/subcomponents/ProviderInfo.tsx
@@ -27,12 +27,7 @@ const ProviderInfo = (props) => {
         const res2 = await fetch(`https://maps.googleapis.com/maps/api/staticmap?center=${props.item.latitude},${props.item.longitude}&zoom=16&scale=2&size=335x250&maptype=roadmap&key=${GOOGLE_API_KEY}&format=png&visual_refresh=true`
              + `&markers=${props.item.latitude},${props.item.longitude}`);
         setStreetView(res2.url);
-        if (typeof props.item.imageURL === 'string') {
-          setImage(props.item.imageURL);
-        } else {
-          const res = await fetch(`https://maps.googleapis.com/maps/api/streetview?size=500x500&location=${props.item.latitude},${props.item.longitude}&fov=80&heading=70&pitch=0&key=${GOOGLE_API_KEY}`);
-          setImage(res.url);
-        }
+        setImage(props.item.imageURL);
         setIsLoading(false);
       } catch (e) {
         setIsLoading(false);


### PR DESCRIPTION
- Downloads provider image from google streets api if not specified in the add provider form
- Removes no longer needed google streets api calls in map and dashboard
- Downloaded and updated firebase for all existing providers with google streets api images