### PR TITLE
Fix/edit provider refresh redirect

### DIFF
--- a/src/components/dashboard/AddProvider.tsx
+++ b/src/components/dashboard/AddProvider.tsx
@@ -58,16 +58,16 @@ function AddProvider(props) {
     };
 
     useEffect(() => {
-        console.log((sessionStorage.getItem("item")))
-        if (firstLoad === false) {
+        if (props.selected !== null) {
             sessionStorage.setItem('item', JSON.stringify(item))
-        } else {
-            if(JSON.parse(sessionStorage.getItem("item")) !== null) {
-                setItem(JSON.parse(sessionStorage.getItem("item")))
-            }
-            setFirstLoad(false)
         }
-    }, [item])
+    }, [props]);
+
+    useEffect(() => {
+        if(JSON.parse(sessionStorage.getItem("item")) !== null) {
+            setItem(JSON.parse(sessionStorage.getItem("item")))
+        }
+    }, []);
 
     useEffect(() => {
         async function fetchData() {
@@ -392,14 +392,14 @@ function AddProvider(props) {
                                     block
                                     disabled={!completed}
                                     onClick={
-                                        props.selected &&
-                                            props.selected.facilityName
+                                        item &&
+                                            item.facilityName
                                             ? updateFirestore
                                             : addFirestore
                                     }
                                 >
-                                    {props.selected &&
-                                        props.selected.facilityName
+                                    {item &&
+                                        item.facilityName
                                         ? "Edit"
                                         : "Add"}{" "}
                                     Provider
@@ -445,9 +445,8 @@ function AddProvider(props) {
                                                         onClick={
                                                             step ===
                                                                 steps.length - 1
-                                                                ? props.selected &&
-                                                                    props.selected
-                                                                        .facilityName
+                                                                ? item &&
+                                                                    item.facilityName
                                                                     ? updateFirestore
                                                                     : addFirestore
                                                                 : next
@@ -461,9 +460,8 @@ function AddProvider(props) {
                                                     >
                                                         {step ===
                                                             steps.length - 1
-                                                            ? props.selected &&
-                                                                props.selected
-                                                                    .facilityName
+                                                            ? item &&
+                                                                item.facilityName
                                                                 ? "Edit Provider"
                                                                 : "Add Provider"
                                                             : "Next"}

--- a/src/components/dashboard/AddProvider.tsx
+++ b/src/components/dashboard/AddProvider.tsx
@@ -39,18 +39,37 @@ let steps = [
 ];
 
 function AddProvider(props) {
+    const defaultItem = {
+        facilityName: "",
+        address: [],
+        description: "",
+        buildingNum: [],
+        stationNum: "",
+        childcare: [false],
+        epic: [false],
+        hours: {},
+        links: {},
+        notes: [],
+        phoneNum: [],
+        website: [],
+        image: "modalimage.png",
+        imageURL: null,
+        content: {},
+        filters: {},
+    };
     const { width } = useWindowSize();
     const [step, setStep] = useState(0);
     const [completed, setCompleted] = useState(false);
     const [animate, setAnimate] = useState(true);
     const [item, setItem] = useState((JSON.parse(sessionStorage.getItem("item")) !== null 
-                                    ? JSON.parse(sessionStorage.getItem("item")) : props.selected) || {});
+                                    ? JSON.parse(sessionStorage.getItem("item")) : 
+                                    (props.selected !== null && Object.keys(props.selected).length > 0 
+                                    ? props.selected : defaultItem)))
     const [isLoading, setIsLoading] = useState(true);
     const [filters, setFilters] = useState(null);
     const [descriptions, setDescriptions] = useState(null);
     const [single, setSingle] = useState(null);
     const [error, setError] = useState("");
-    const [firstLoad, setFirstLoad] = useState(true);
     const [content, setContent] = useState(
         'ex. "Changing lives one bit at a time..."'
     );
@@ -60,12 +79,11 @@ function AddProvider(props) {
 
     // selected provider persists on refresh when attempting to edit
     useEffect(() => {
-        console.log(props)
         if (JSON.parse(sessionStorage.getItem("item")) == null || Object.keys(item).length > 0) {
             sessionStorage.setItem('item', JSON.stringify(item))
-            console.log("set sessionStorage: ")
-            console.log(JSON.parse(sessionStorage.getItem("item")))
+            console.log("stored")
         }
+        console.log("item:", item)
     }, [item]);
 
     useEffect(() => {
@@ -398,13 +416,13 @@ function AddProvider(props) {
                                     disabled={!completed}
                                     onClick={
                                         item &&
-                                            item.facilityName
+                                            item.id
                                             ? updateFirestore
                                             : addFirestore
                                     }
                                 >
                                     {item &&
-                                        item.facilityName
+                                        item.id
                                         ? "Edit"
                                         : "Add"}{" "}
                                     Provider
@@ -451,7 +469,7 @@ function AddProvider(props) {
                                                             step ===
                                                                 steps.length - 1
                                                                 ? item &&
-                                                                    item.facilityName
+                                                                    item.id
                                                                     ? updateFirestore
                                                                     : addFirestore
                                                                 : next
@@ -466,7 +484,7 @@ function AddProvider(props) {
                                                         {step ===
                                                             steps.length - 1
                                                             ? item &&
-                                                                item.facilityName
+                                                                item.id
                                                                 ? "Edit Provider"
                                                                 : "Add Provider"
                                                             : "Next"}
@@ -500,6 +518,8 @@ function AddProvider(props) {
                                                                 i
                                                             );
                                                         setItem(i);
+                                                        console.log(item)
+                                                        console.log("item set", i)
                                                         setCompleted(c);
                                                     }}
                                                     filters={filters}

--- a/src/components/dashboard/AddProvider.tsx
+++ b/src/components/dashboard/AddProvider.tsx
@@ -59,10 +59,10 @@ function AddProvider(props) {
 
     // selected provider persists on refresh when attempting to edit
     useEffect(() => {
-        if (props.selected !== null) {
+        if ((item !== null) && (Object.keys(item).length > 0)) {
             sessionStorage.setItem('item', JSON.stringify(item))
         }
-    }, [props]);
+    }, [item]);
 
     useEffect(() => {
         if(JSON.parse(sessionStorage.getItem("item")) !== null) {

--- a/src/components/dashboard/AddProvider.tsx
+++ b/src/components/dashboard/AddProvider.tsx
@@ -57,6 +57,7 @@ function AddProvider(props) {
         setContent(updatedContent);
     };
 
+    // selected provider persists on refresh when attempting to edit
     useEffect(() => {
         if (props.selected !== null) {
             sessionStorage.setItem('item', JSON.stringify(item))

--- a/src/components/dashboard/AddProvider.tsx
+++ b/src/components/dashboard/AddProvider.tsx
@@ -43,7 +43,8 @@ function AddProvider(props) {
     const [step, setStep] = useState(0);
     const [completed, setCompleted] = useState(false);
     const [animate, setAnimate] = useState(true);
-    const [item, setItem] = useState(props.selected || {});
+    const [item, setItem] = useState((JSON.parse(sessionStorage.getItem("item")) !== null 
+                                    ? JSON.parse(sessionStorage.getItem("item")) : props.selected) || {});
     const [isLoading, setIsLoading] = useState(true);
     const [filters, setFilters] = useState(null);
     const [descriptions, setDescriptions] = useState(null);
@@ -59,8 +60,11 @@ function AddProvider(props) {
 
     // selected provider persists on refresh when attempting to edit
     useEffect(() => {
-        if ((item !== null) && (Object.keys(item).length > 0)) {
+        console.log(props)
+        if (JSON.parse(sessionStorage.getItem("item")) == null || Object.keys(item).length > 0) {
             sessionStorage.setItem('item', JSON.stringify(item))
+            console.log("set sessionStorage: ")
+            console.log(JSON.parse(sessionStorage.getItem("item")))
         }
     }, [item]);
 

--- a/src/components/dashboard/RowForm.tsx
+++ b/src/components/dashboard/RowForm.tsx
@@ -52,7 +52,7 @@ const RowForm = (props) => {
     };
 
     const [item, setItem] = useState(
-        props.item.facilityName ? props.item : JSON.parse(sessionStorage.getItem("item")) || defaultItem
+        props.item.facilityName ? props.item : defaultItem
     );
     const [showModal, setShowModal] = useState(false);
 

--- a/src/components/dashboard/RowForm.tsx
+++ b/src/components/dashboard/RowForm.tsx
@@ -32,27 +32,10 @@ function validURL(str) {
 }
 
 const RowForm = (props) => {
-    const defaultItem = {
-        facilityName: "",
-        address: [],
-        description: "",
-        buildingNum: [],
-        stationNum: "",
-        childcare: [false],
-        epic: [false],
-        hours: {},
-        links: {},
-        notes: [],
-        phoneNum: [],
-        website: [],
-        image: "modalimage.png",
-        imageURL: null,
-        content: {},
-        filters: {},
-    };
+
 
     const [item, setItem] = useState(
-        props.item.facilityName ? props.item : defaultItem
+        props.item.id ? props.item : JSON.parse(sessionStorage.getItem("item"))
     );
     const [showModal, setShowModal] = useState(false);
 


### PR DESCRIPTION
Fixed Issue #341 where refreshing on the edit page redirects to the add page and the selected provider is cleared. 
Selected provider now persists on refresh when attempting to edit, and the edit page is still present on refresh.